### PR TITLE
RetrieveCredentialFromVault exception not caught when .NET Native is enabled

### DIFF
--- a/src/OneDrive.Sdk.Authentication.WinStore/CredentialVault.cs
+++ b/src/OneDrive.Sdk.Authentication.WinStore/CredentialVault.cs
@@ -73,7 +73,7 @@ namespace Microsoft.OneDrive.Sdk.Authentication
             {
                 creds = vault.Retrieve(CredentialVault.VaultResourceName, this.ClientId);
             }
-            catch (System.Runtime.InteropServices.COMException)
+            catch (Exception)
             {
                 // This happens when the vault is empty. Swallow.
             }


### PR DESCRIPTION
When a UWP (14393 SDK) is running in Release mode with .NET Native
enabled, the exception is not caught when the vault is unable to
retrieve the credential because the vault is empty.

Changing the exception type that's caught addresses the issue.