### PR TITLE
Add methods to restore user session from cache without showing sign in UI

### DIFF
--- a/src/OneDrive.Sdk.Authentication.Common/MsaAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.Common/MsaAuthenticationProvider.cs
@@ -295,6 +295,33 @@ namespace Microsoft.OneDrive.Sdk.Authentication
         }
 
         /// <summary>
+        /// used credentials if available, without showing the sign in UI if credentials are unavailable.
+        /// </summary>
+        /// <param name="userName">The login name of the user, if known.</param>
+        /// <returns>The authentication token.</returns>
+        public async Task RestoreMostRecentFromCacheAsync(string userName = null)
+        {
+            using (var httpProvider = new HttpProvider())
+            {
+                await this.RestoreMostRecentFromCacheAsync(httpProvider, userName).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="httpProvider">HttpProvider for any web requests needed for authentication</param>
+        /// <param name="userName">The login name of the user, if known.</param>
+        /// <returns>The authentication token.</returns>
+        public async Task RestoreMostRecentFromCacheAsync(IHttpProvider httpProvider, string userName = null)
+        {
+            var authResult = await this.GetMostRecentAuthenticationResultFromCacheAsync(httpProvider).ConfigureAwait(false);
+            if (authResult != null)
+            {
+                this.CacheAuthResult(authResult);
+            }
+        }
+
+        /// <summary>
         /// Retrieves the authentication token.
         /// </summary>
         /// <param name="userName">The login name of the user, if known.</param>

--- a/src/OneDrive.Sdk.Authentication.Common/MsaAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.Common/MsaAuthenticationProvider.cs
@@ -295,6 +295,7 @@ namespace Microsoft.OneDrive.Sdk.Authentication
         }
 
         /// <summary>
+        /// Retrieves the authentication token. Retrieves the most recently
         /// used credentials if available, without showing the sign in UI if credentials are unavailable.
         /// </summary>
         /// <param name="userName">The login name of the user, if known.</param>
@@ -308,6 +309,8 @@ namespace Microsoft.OneDrive.Sdk.Authentication
         }
 
         /// <summary>
+        /// Retrieves the authentication token. Retrieves the most recently
+        /// used credentials if available, without showing the sign in UI if credentials are unavailable.
         /// </summary>
         /// <param name="httpProvider">HttpProvider for any web requests needed for authentication</param>
         /// <param name="userName">The login name of the user, if known.</param>

--- a/src/OneDrive.Sdk.Authentication.Common/MsaAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.Common/MsaAuthenticationProvider.cs
@@ -300,11 +300,11 @@ namespace Microsoft.OneDrive.Sdk.Authentication
         /// </summary>
         /// <param name="userName">The login name of the user, if known.</param>
         /// <returns>The authentication token.</returns>
-        public async Task RestoreMostRecentFromCacheAsync(string userName = null)
+        public async Task<bool> RestoreMostRecentFromCacheAsync(string userName = null)
         {
             using (var httpProvider = new HttpProvider())
             {
-                await this.RestoreMostRecentFromCacheAsync(httpProvider, userName).ConfigureAwait(false);
+                return await this.RestoreMostRecentFromCacheAsync(httpProvider, userName).ConfigureAwait(false);
             }
         }
 
@@ -315,13 +315,14 @@ namespace Microsoft.OneDrive.Sdk.Authentication
         /// <param name="httpProvider">HttpProvider for any web requests needed for authentication</param>
         /// <param name="userName">The login name of the user, if known.</param>
         /// <returns>The authentication token.</returns>
-        public async Task RestoreMostRecentFromCacheAsync(IHttpProvider httpProvider, string userName = null)
+        public async Task<bool> RestoreMostRecentFromCacheAsync(IHttpProvider httpProvider, string userName = null)
         {
             var authResult = await this.GetMostRecentAuthenticationResultFromCacheAsync(httpProvider).ConfigureAwait(false);
             if (authResult != null)
             {
                 this.CacheAuthResult(authResult);
             }
+            return authResult != null;
         }
 
         /// <summary>


### PR DESCRIPTION
In 1.0.4, support was added to cache and restore a session so that it was unnecessary to prompt the user to sign in each time the service was accessed. However, this new method coupled together restoring the session and showing the sign in UI if the credentials were invalid.

This is problematic because there are several scenarios where it's important to separate out restoring a session and showing sign in UI:
 - Restoring a session from a background task where UI cannot be raised.
 - Restoring a session from within an app, but where it's important for the app to have full control over the sign in flow. For example, if an app automatically contacts the service on app launch, it would be far more elegant for the app to show an inline message that the user must re-authenticate, rather than just randomly showing the sign in UI without explanation.
 
To address these scenarios, this change adds a new set of methods that only restores the session without showing the sign in UI.
 
Tested changes with a UWP targeting the 14393 SDK, both in the foreground and in a background task.