### PR TITLE
Onlineid auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ var msaAuthenticationProvider = new MsaAuthenticationProvider(
 
 The MsaAuthenticationProvider constructor has an overload that takes in client secret for platforms that support web clients.
 
+If you are building a UWP app, you can leverage the user's signed-in account. Simply construct an `OnlineIdAuthenticationProvider`:
+
+```csharp
+var msaAuthenticationProvider = new OnlineIdAuthenticationProvider(scopes);
+```
+
+This type inherits from `MsaAuthenticationProvider` and behaves similarly. It will also refresh the user's token as needed.
+
 #### Authenticate a user
 
 ```csharp
@@ -105,6 +113,7 @@ var msaAuthProvider = new MsaAuthenticationProvider(
     clientId,
     returnUrl,
     scopes,
+    /*CredentialCache*/ null,
     new CredentialVault(clientId));
 authTask = msaAuthProvider.RestoreMostRecentFromCacheOrAuthenticateUserAsync();
 app.OneDriveClient = new OneDriveClient(this.oneDriveConsumerBaseUrl, msaAuthProvider);
@@ -115,6 +124,8 @@ If a previous session is found with a refresh token, then its redemption will be
 will not see authentication UI at all.
 
 To clear out this cache, simply call `await MsaAuthenticationProvider.SignOutAsync()`. The contents of the cache will be deleted.
+
+Note: CredentialVault is not necassary if you are using `OnlineIdAuthenticationProvider`.
 
 ## Documentation and resources
 

--- a/src/OneDrive.Sdk.Authentication.Common/MsaAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.Common/MsaAuthenticationProvider.cs
@@ -20,10 +20,10 @@ namespace Microsoft.OneDrive.Sdk.Authentication
     /// </summary>
     public class MsaAuthenticationProvider : IAuthenticationProvider
     {
-        private readonly string clientId;
-        private readonly string clientSecret;
-        private readonly string returnUrl;
-        private readonly string[] scopes;
+        internal readonly string clientId;
+        internal string clientSecret;
+        internal string returnUrl;
+        internal string[] scopes;
         
         private OAuthHelper oAuthHelper;
 
@@ -313,7 +313,7 @@ namespace Microsoft.OneDrive.Sdk.Authentication
         /// <param name="httpProvider">HttpProvider for any web requests needed for authentication</param>
         /// <param name="userName">The login name of the user, if known.</param>
         /// <returns>The authentication token.</returns>
-        public async Task AuthenticateUserAsync(IHttpProvider httpProvider, string userName = null)
+        public virtual async Task AuthenticateUserAsync(IHttpProvider httpProvider, string userName = null)
         {
             var authResult = await this.GetAuthenticationResultFromCacheAsync(userName, httpProvider).ConfigureAwait(false);
 

--- a/src/OneDrive.Sdk.Authentication.Common/MsaAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.Common/MsaAuthenticationProvider.cs
@@ -409,7 +409,7 @@ namespace Microsoft.OneDrive.Sdk.Authentication
             }
         }
 
-        internal async Task<AccountSession> ProcessCachedAccountSessionAsync(AccountSession accountSession, IHttpProvider httpProvider)
+        internal virtual async Task<AccountSession> ProcessCachedAccountSessionAsync(AccountSession accountSession, IHttpProvider httpProvider)
         {
             if (accountSession != null)
             {

--- a/src/OneDrive.Sdk.Authentication.WinStore/OneDrive.Sdk.Authentication.WinStore.csproj
+++ b/src/OneDrive.Sdk.Authentication.WinStore/OneDrive.Sdk.Authentication.WinStore.csproj
@@ -76,6 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CredentialVault.cs" />
+    <Compile Include="OnlineIdAuthenticationProvider.cs" />
     <Compile Include="WebAuthenticationBrokerWebAuthenticationUi.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
@@ -22,61 +22,67 @@
 
 namespace Microsoft.OneDrive.Sdk
 {
+    using Microsoft.Graph;
+    using Microsoft.OneDrive.Sdk.Authentication;
+
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using Windows.Security.Authentication.OnlineId;
 
-    public class OnlineIdAuthenticationProvider : AuthenticationProvider
+    public class OnlineIdAuthenticationProvider : MsaAuthenticationProvider
     {
-        private OnlineIdAuthenticator authenticator;
+        private readonly int ticketExpirationTimeInMinutes = 60;
+        private readonly OnlineIdAuthenticator authenticator;
 
-        public OnlineIdAuthenticationProvider(ServiceInfo serviceInfo)
-            : base(serviceInfo)
+        public OnlineIdAuthenticationProvider(
+            string clientId,
+            string returnUrl,
+            string[] scopes)
+            :base(clientId, returnUrl, scopes)
         {
             this.authenticator = new OnlineIdAuthenticator();
         }
 
-        /// <summary>
-        /// Signs the current user out.
-        /// </summary>
-        public override async Task SignOutAsync()
+        public override async Task AuthenticateUserAsync(IHttpProvider httpProvider, string userName = null)
         {
-            if (this.CurrentAccountSession != null && this.CurrentAccountSession.CanSignOut)
+            var authResult = await this.GetAuthenticationResultFromCacheAsync(userName, httpProvider);
+
+            if (authResult == null)
             {
-                if (this.authenticator.CanSignOut)
+                authResult = await this.GetAccountSessionAsync();
+
+                if (authResult == null || string.IsNullOrEmpty(authResult.AccessToken))
                 {
-                    await this.authenticator.SignOutUserAsync();
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = OAuthConstants.ErrorCodes.AuthenticationFailure,
+                            Message = "Failed to retrieve a valid authentication token for the user."
+                        });
                 }
-
-                this.DeleteUserCredentialsFromCache(this.CurrentAccountSession);
-                this.CurrentAccountSession = null;
             }
-        }
-
-        protected override Task<AccountSession> GetAuthenticationResultAsync()
-        {
-            return this.GetAccountSessionAsync();
+            
+            this.CacheAuthResult(authResult);
         }
 
         internal async Task<AccountSession> GetAccountSessionAsync()
         {
             try
             {
-                var serviceTicketRequest = new OnlineIdServiceTicketRequest(string.Join(" ", this.ServiceInfo.Scopes), "DELEGATION");
-                var ticketRequests = new List<OnlineIdServiceTicketRequest>();
-                ticketRequests.Add(serviceTicketRequest);
-                var authenticationResponse = await this.authenticator.AuthenticateUserAsync(ticketRequests, (Windows.Security.Authentication.OnlineId.CredentialPromptType) this.ServiceInfo.MicrosoftAccountPromptType);
+                var serviceTicketRequest = new OnlineIdServiceTicketRequest(string.Join(" ", this.scopes), "DELEGATION");
+                var ticketRequests = new List<OnlineIdServiceTicketRequest> { serviceTicketRequest };
+                var authenticationResponse = await this.authenticator.AuthenticateUserAsync(ticketRequests, Windows.Security.Authentication.OnlineId.CredentialPromptType.PromptIfNeeded);
 
                 var ticket = authenticationResponse.Tickets.FirstOrDefault();
 
                 if (ticket == null || string.IsNullOrEmpty(ticket.Value))
                 {
-                    throw new OneDriveException(
+                    throw new ServiceException(
                         new Error
                         {
-                            Code = OneDriveErrorCode.AuthenticationFailure.ToString(),
+                            Code = OAuthConstants.ErrorCodes.AuthenticationFailure,
                             Message = string.Format(
                                 "Failed to retrieve a valid authentication token from OnlineIdAuthenticator for user {0}.",
                                 authenticationResponse.SignInName)
@@ -86,17 +92,21 @@ namespace Microsoft.OneDrive.Sdk
                 var accountSession = new AccountSession
                 {
                     AccessToken = ticket == null ? null : ticket.Value,
-                    AccountType = this.ServiceInfo.AccountType,
-                    CanSignOut = this.authenticator.CanSignOut,
+                    ExpiresOnUtc = DateTimeOffset.UtcNow.AddMinutes(this.ticketExpirationTimeInMinutes),
+                    //CanSignOut = this.authenticator.CanSignOut,
                     ClientId = this.authenticator.ApplicationId.ToString(),
-                    UserId = authenticationResponse.SafeCustomerId,
+                    UserId = authenticationResponse.SafeCustomerId
                 };
 
                 return accountSession;
             }
+            catch (TaskCanceledException taskCanceledException)
+            {
+                throw new ServiceException(new Error { Code = OAuthConstants.ErrorCodes.AuthenticationCancelled, Message = "Authentication was canceled." }, taskCanceledException);
+            }
             catch (Exception exception)
             {
-                throw new OneDriveException(new Error { Code = OneDriveErrorCode.AuthenticationFailure.ToString(), Message = exception.Message }, exception);
+                throw new ServiceException(new Error { Code = OAuthConstants.ErrorCodes.AuthenticationFailure, Message = exception.Message }, exception);
             }
         }
     }

--- a/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
@@ -112,11 +112,18 @@ namespace Microsoft.OneDrive.Sdk
 
         internal override async Task<AccountSession> ProcessCachedAccountSessionAsync(AccountSession accountSession, IHttpProvider httpProvider)
         {
-            if (accountSession != null && accountSession.ShouldRefresh)
+            if (accountSession != null)
             {
-                accountSession = await this.GetAccountSessionAsync();
+                if (accountSession.ShouldRefresh) // Don't check 'CanRefresh' because this type can always refresh
+                {
+                    accountSession = await this.GetAccountSessionAsync();
 
-                if (accountSession != null && !string.IsNullOrEmpty(accountSession.AccessToken))
+                    if (accountSession != null && !string.IsNullOrEmpty(accountSession.AccessToken))
+                    {
+                        return accountSession;
+                    }
+                }
+                else
                 {
                     return accountSession;
                 }

--- a/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
@@ -109,5 +109,20 @@ namespace Microsoft.OneDrive.Sdk
                 throw new ServiceException(new Error { Code = OAuthConstants.ErrorCodes.AuthenticationFailure, Message = exception.Message }, exception);
             }
         }
+
+        internal override async Task<AccountSession> ProcessCachedAccountSessionAsync(AccountSession accountSession, IHttpProvider httpProvider)
+        {
+            if (accountSession != null && accountSession.ShouldRefresh)
+            {
+                accountSession = await this.GetAccountSessionAsync();
+
+                if (accountSession != null && !string.IsNullOrEmpty(accountSession.AccessToken))
+                {
+                    return accountSession;
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
@@ -33,6 +33,7 @@ namespace Microsoft.OneDrive.Sdk
 
     public class OnlineIdAuthenticationProvider : MsaAuthenticationProvider
     {
+        private const string onlineIdServiceTicketRequestType = "DELEGATION";
         private readonly int ticketExpirationTimeInMinutes = 60;
         private readonly OnlineIdAuthenticator authenticator;
 
@@ -69,7 +70,7 @@ namespace Microsoft.OneDrive.Sdk
         {
             try
             {
-                var serviceTicketRequest = new OnlineIdServiceTicketRequest(string.Join(" ", this.scopes), "DELEGATION");
+                var serviceTicketRequest = new OnlineIdServiceTicketRequest(string.Join(" ", this.scopes), onlineIdServiceTicketRequestType);
                 var ticketRequests = new List<OnlineIdServiceTicketRequest> { serviceTicketRequest };
                 var authenticationResponse = await this.authenticator.AuthenticateUserAsync(ticketRequests, Windows.Security.Authentication.OnlineId.CredentialPromptType.PromptIfNeeded);
 

--- a/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
@@ -37,10 +37,8 @@ namespace Microsoft.OneDrive.Sdk
         private readonly OnlineIdAuthenticator authenticator;
 
         public OnlineIdAuthenticationProvider(
-            string clientId,
-            string returnUrl,
             string[] scopes)
-            :base(clientId, returnUrl, scopes)
+            :base(null, null, scopes)
         {
             this.authenticator = new OnlineIdAuthenticator();
         }
@@ -53,7 +51,7 @@ namespace Microsoft.OneDrive.Sdk
             {
                 authResult = await this.GetAccountSessionAsync();
 
-                if (authResult == null || string.IsNullOrEmpty(authResult.AccessToken))
+                if (string.IsNullOrEmpty(authResult?.AccessToken))
                 {
                     throw new ServiceException(
                         new Error
@@ -77,7 +75,7 @@ namespace Microsoft.OneDrive.Sdk
 
                 var ticket = authenticationResponse.Tickets.FirstOrDefault();
 
-                if (ticket == null || string.IsNullOrEmpty(ticket.Value))
+                if (string.IsNullOrEmpty(ticket?.Value))
                 {
                     throw new ServiceException(
                         new Error
@@ -91,9 +89,8 @@ namespace Microsoft.OneDrive.Sdk
 
                 var accountSession = new AccountSession
                 {
-                    AccessToken = ticket == null ? null : ticket.Value,
+                    AccessToken = string.IsNullOrEmpty(ticket.Value) ? null : ticket.Value,
                     ExpiresOnUtc = DateTimeOffset.UtcNow.AddMinutes(this.ticketExpirationTimeInMinutes),
-                    //CanSignOut = this.authenticator.CanSignOut,
                     ClientId = this.authenticator.ApplicationId.ToString(),
                     UserId = authenticationResponse.SafeCustomerId
                 };
@@ -117,8 +114,8 @@ namespace Microsoft.OneDrive.Sdk
                 if (accountSession.ShouldRefresh) // Don't check 'CanRefresh' because this type can always refresh
                 {
                     accountSession = await this.GetAccountSessionAsync();
-
-                    if (accountSession != null && !string.IsNullOrEmpty(accountSession.AccessToken))
+                    
+                    if (!string.IsNullOrEmpty(accountSession?.AccessToken))
                     {
                         return accountSession;
                     }


### PR DESCRIPTION
I don't love having a different class for this, but it does require some significantly different interactions with the cache (for example, this auth type can never refresh using a refresh token). Would be possible to refactor into a common base class and use delegates for interacting with the cache, but it seems like a lot of work for very little gain. Let me know what you think.