### PR TITLE
Add background task support for OnlineIdAuthenticationProvider

### DIFF
--- a/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
@@ -36,12 +36,14 @@ namespace Microsoft.OneDrive.Sdk
         private const string onlineIdServiceTicketRequestType = "DELEGATION";
         private readonly int ticketExpirationTimeInMinutes = 60;
         private readonly OnlineIdAuthenticator authenticator;
+        private readonly CredentialPromptType credentialPromptType;
 
         public OnlineIdAuthenticationProvider(
-            string[] scopes)
+            string[] scopes, CredentialPromptType credentialPromptType = CredentialPromptType.PromptIfNeeded)
             :base(null, null, scopes)
         {
             this.authenticator = new OnlineIdAuthenticator();
+            this.credentialPromptType = credentialPromptType;
         }
 
         public override async Task AuthenticateUserAsync(IHttpProvider httpProvider, string userName = null)
@@ -89,7 +91,7 @@ namespace Microsoft.OneDrive.Sdk
             {
                 var serviceTicketRequest = new OnlineIdServiceTicketRequest(string.Join(" ", this.scopes), onlineIdServiceTicketRequestType);
                 var ticketRequests = new List<OnlineIdServiceTicketRequest> { serviceTicketRequest };
-                var authenticationResponse = await this.authenticator.AuthenticateUserAsync(ticketRequests, Windows.Security.Authentication.OnlineId.CredentialPromptType.PromptIfNeeded);
+                var authenticationResponse = await this.authenticator.AuthenticateUserAsync(ticketRequests, credentialPromptType);
 
                 var ticket = authenticationResponse.Tickets.FirstOrDefault();
 

--- a/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
@@ -40,9 +40,9 @@ namespace Microsoft.OneDrive.Sdk
 
         public enum PromptType
         {
-            PromptIfNeeded,
-            RetypeCredentials,
-            DoNotPrompt
+            PromptIfNeeded = CredentialPromptType.PromptIfNeeded,
+            RetypeCredentials = CredentialPromptType.RetypeCredentials,
+            DoNotPrompt = CredentialPromptType.DoNotPrompt
         }
 
         public OnlineIdAuthenticationProvider(

--- a/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDrive.Sdk.Authentication.WinStore/OnlineIdAuthenticationProvider.cs
@@ -38,12 +38,19 @@ namespace Microsoft.OneDrive.Sdk
         private readonly OnlineIdAuthenticator authenticator;
         private readonly CredentialPromptType credentialPromptType;
 
+        public enum PromptType
+        {
+            PromptIfNeeded,
+            RetypeCredentials,
+            DoNotPrompt
+        }
+
         public OnlineIdAuthenticationProvider(
-            string[] scopes, CredentialPromptType credentialPromptType = CredentialPromptType.PromptIfNeeded)
+            string[] scopes, PromptType promptType = PromptType.PromptIfNeeded)
             :base(null, null, scopes)
         {
             this.authenticator = new OnlineIdAuthenticator();
-            this.credentialPromptType = credentialPromptType;
+            this.credentialPromptType = (CredentialPromptType)promptType;
         }
 
         public override async Task AuthenticateUserAsync(IHttpProvider httpProvider, string userName = null)


### PR DESCRIPTION
This pull request adds support for `OnlineIdAuthenticationProvider` in a background task.

Adds `CredentialPromptType` as an optional constructor argument. Using
`CredentialPromptType.DoNotPrompt` allows for background task usage.
`CredentialPromptType.PromptIfNeeded` is still the default.

See the issue for more details: #21 