### PR TITLE
Credential file not read correctly. Write location is different from …

### DIFF
--- a/src/OneDrive.Sdk.Authentication.Desktop/CredentialVault.cs
+++ b/src/OneDrive.Sdk.Authentication.Desktop/CredentialVault.cs
@@ -37,12 +37,13 @@ namespace Microsoft.OneDrive.Sdk.Authentication
         public void AddCredentialCacheToVault(CredentialCache credentialCache)
         {
             this.DeleteStoredCredentialCache();
-            
+
             var cacheBlob = this.Protect(credentialCache.GetCacheBlob());
-            using (var outStream = File.OpenWrite(this.VaultFileName))
+            string filePath = this.GetVaultFilePath();
+            using (var outStream = File.OpenWrite(filePath))
             {
                 outStream.Write(cacheBlob, 0, cacheBlob.Length);
-            } 
+            }
         }
 
         public bool RetrieveCredentialCache(CredentialCache credentialCache)


### PR DESCRIPTION
…Read location.

The credential file was being written to the CWD, but being read from AppData. This resulted in the OAuth Consent Prompt being created for every token request.