### PR TITLE
fix json parse failure in SendTokenRequestAsync

### DIFF
--- a/src/OneDrive.Sdk.Authentication.Desktop/packages.config
+++ b/src/OneDrive.Sdk.Authentication.Desktop/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Graph.Core" version="1.3.1" targetFramework="net451" />
+  <package id="Microsoft.Graph.Core" version="1.6.0" targetFramework="net451" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.21.301221612" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
fix for https://github.com/OneDrive/onedrive-sdk-dotnet-msa-auth-adapter/issues/70